### PR TITLE
[WIP] Fix ssl cert errors (SCT-819)

### DIFF
--- a/deps/pylib.sh
+++ b/deps/pylib.sh
@@ -1,2 +1,2 @@
 pip install gdapi-python
-pip install websocket-client
+pip install websocket-client==0.40.0


### PR DESCRIPTION
websocket-client needs to be 0.40.0 to avoid ssl errors.  See https://github.com/kubernetes-client/python/issues/300 for some more detail.